### PR TITLE
Allow setup of AUS and NOTAUS zones ids

### DIFF
--- a/src/main/java/au/org/ala/sds/model/SensitiveTaxon.java
+++ b/src/main/java/au/org/ala/sds/model/SensitiveTaxon.java
@@ -157,11 +157,11 @@ public class SensitiveTaxon implements Serializable, Comparable<SensitiveTaxon> 
             if (zones.contains(si.getZone())) {
                 instanceList.add(si);
             } else if (
-                    SensitivityZoneFactory.getZone(SensitivityZone.AUS) != null &&
+                    SensitivityZoneFactory.getZone(SensitivityZone.ATLAS_COUNTRY_CODE) != null &&
                             si != null &&
                             si.getZone() != null &&
-                    si.getZone().equals(SensitivityZoneFactory.getZone(SensitivityZone.AUS)) &&
-                    SensitivityZone.isInAustralia(zones)
+                    si.getZone().equals(SensitivityZoneFactory.getZone(SensitivityZone.ATLAS_COUNTRY_CODE)) &&
+                    SensitivityZone.isInAtlasCountry(zones)
                 ) {
                 instanceList.add(si);
             }
@@ -180,7 +180,7 @@ public class SensitiveTaxon implements Serializable, Comparable<SensitiveTaxon> 
             if (state == si.getZone()) {
                 instance = si;
             } else {
-                if (si.getZone() == SensitivityZoneFactory.getZone(SensitivityZone.AUS)) {
+                if (si.getZone() == SensitivityZoneFactory.getZone(SensitivityZone.ATLAS_COUNTRY_CODE)) {
                     ausInstance = si;
                 }
             }

--- a/src/main/java/au/org/ala/sds/model/SensitivityZone.java
+++ b/src/main/java/au/org/ala/sds/model/SensitivityZone.java
@@ -3,7 +3,7 @@ package au.org.ala.sds.model;
 import java.io.Serializable;
 import java.util.*;
 
-import org.apache.commons.collections.comparators.ComparableComparator;
+import au.org.ala.sds.util.Configuration;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -12,8 +12,8 @@ public class SensitivityZone implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String AUS = "AUS";
-    public static final String NOTAUS = "NOTAUS";
+    public static final String ATLAS_COUNTRY_CODE = Configuration.getInstance().getCountryId();
+    public static final String NOT_ATLAS_COUNTRY_CODE = Configuration.getInstance().getNotCountryId();
     public static final String ACT = "ACT";
     public static final String NSW = "NSW";
     public static final String QLD = "QLD";
@@ -116,15 +116,15 @@ public class SensitivityZone implements Serializable {
         return "{\"name\":\"" + name + "\", \"type\":\"" + type.toString() + "\"}";
     }
 
-    public static boolean isInAustralia(SensitivityZone zone) {
+    public static boolean isInAtlasCountry(SensitivityZone zone) {
         return
-            zone == SensitivityZoneFactory.getZone(AUS) ||
+            zone == SensitivityZoneFactory.getZone(ATLAS_COUNTRY_CODE) ||
             zone.getType() == ZoneType.STATE;
     }
 
-    public static boolean isInAustralia(List<SensitivityZone> zones) {
+    public static boolean isInAtlasCountry(List<SensitivityZone> zones) {
         for (SensitivityZone zone : zones) {
-            if (zone.equals(SensitivityZoneFactory.getZone(AUS)) || zone.getType() == ZoneType.STATE) {
+            if (zone.equals(SensitivityZoneFactory.getZone(ATLAS_COUNTRY_CODE)) || zone.getType() == ZoneType.STATE) {
                 return true;
             }
         }
@@ -153,13 +153,13 @@ public class SensitivityZone implements Serializable {
         return false;
     }
 
-    public static boolean isNotInAustralia(SensitivityZone zone) {
-        return zone == null || zone.equals(SensitivityZoneFactory.getZone(NOTAUS));
+    public static boolean isNotInAtlasCountry(SensitivityZone zone) {
+        return zone == null || zone.equals(SensitivityZoneFactory.getZone(NOT_ATLAS_COUNTRY_CODE));
     }
 
-    public static boolean isNotInAustralia(List<SensitivityZone> zones) {
+    public static boolean isNotInAtlasCountry(List<SensitivityZone> zones) {
         for (SensitivityZone zone : zones) {
-            if (zone.equals(SensitivityZoneFactory.getZone(NOTAUS))) {
+            if (zone.equals(SensitivityZoneFactory.getZone(NOT_ATLAS_COUNTRY_CODE))) {
                 return true;
             }
         }

--- a/src/main/java/au/org/ala/sds/util/AUWorkarounds.java
+++ b/src/main/java/au/org/ala/sds/util/AUWorkarounds.java
@@ -116,7 +116,7 @@ public class AUWorkarounds {
                 zones.add(zone);
 
                 if (!"AU".equals(zone.getId())) {
-                    zones.add(SensitivityZoneFactory.getZone(SensitivityZone.NOTAUS));
+                    zones.add(SensitivityZoneFactory.getZone(SensitivityZone.NOT_ATLAS_COUNTRY_CODE));
                 }
             }
         }

--- a/src/main/java/au/org/ala/sds/util/Configuration.java
+++ b/src/main/java/au/org/ala/sds/util/Configuration.java
@@ -99,6 +99,10 @@ public class Configuration {
         return config.getProperty(field,field);
     }
 
+    public String getCountryId() { return config.getProperty("sds.country.id","AUS"); }
+
+    public String getNotCountryId() { return config.getProperty("sds.not.country.id","NOTAUS"); }
+
     public String getFlagRules(){
         return config.getProperty("sds.flag.rules","PBC7,PBC8,PBC9");
     }

--- a/src/main/java/au/org/ala/sds/util/GeneralisedLocation.java
+++ b/src/main/java/au/org/ala/sds/util/GeneralisedLocation.java
@@ -201,7 +201,7 @@ public class GeneralisedLocation {
         //this is where zones are matched to sensitive zone...
         for (SensitivityInstance si : instances) {
             if (si instanceof ConservationInstance) {
-                if (zones.contains(si.getZone()) || (si.getZone().getId().equals(SensitivityZone.AUS) && SensitivityZone.isInAustralia(zones))) {
+                if (zones.contains(si.getZone()) || (si.getZone().getId().equals(SensitivityZone.ATLAS_COUNTRY_CODE) && SensitivityZone.isInAtlasCountry(zones))) {
                     generalisation = maxGeneralisation(generalisation, ((ConservationInstance) si).getLocationGeneralisation());
                 }
             }

--- a/src/main/java/au/org/ala/sds/util/GeoLocationHelper.java
+++ b/src/main/java/au/org/ala/sds/util/GeoLocationHelper.java
@@ -59,7 +59,7 @@ public class GeoLocationHelper {
 
         if (zones.isEmpty()) {
             logger.debug("Zone could not be determined from location: Lat " + latitude + ", Long " + longitude);
-            zones.add(SensitivityZoneFactory.getZone(SensitivityZone.NOTAUS));
+            zones.add(SensitivityZoneFactory.getZone(SensitivityZone.NOT_ATLAS_COUNTRY_CODE));
         }
         return zones;
     }

--- a/src/main/java/au/org/ala/sds/util/ValidationUtils.java
+++ b/src/main/java/au/org/ala/sds/util/ValidationUtils.java
@@ -42,10 +42,10 @@ public class ValidationUtils {
 
         //if country supplied add a zone for it
         if (StringUtils.isNotBlank(country)) {
-            if (country.equalsIgnoreCase(SensitivityZoneFactory.getZone(SensitivityZone.AUS).getName())) {
-                zones.add(SensitivityZoneFactory.getZone(SensitivityZone.AUS));
+            if (country.equalsIgnoreCase(SensitivityZoneFactory.getZone(SensitivityZone.ATLAS_COUNTRY_CODE).getName())) {
+                zones.add(SensitivityZoneFactory.getZone(SensitivityZone.ATLAS_COUNTRY_CODE));
             } else {
-                zones.add(SensitivityZoneFactory.getZone(SensitivityZone.NOTAUS));
+                zones.add(SensitivityZoneFactory.getZone(SensitivityZone.NOT_ATLAS_COUNTRY_CODE));
 
                 countryZone = SensitivityZoneFactory.getZoneByName(country);
                 if(countryZone != null){

--- a/src/main/resources/PBC1-PlantPestNotKnownInAustralia.drl
+++ b/src/main/resources/PBC1-PlantPestNotKnownInAustralia.drl
@@ -35,7 +35,7 @@ end
 //        $map: Map( eval( $map.get("dataResourceUid") !=null ))
 //        //eval(this["dataResourceUid"] ! =null))
 //        // Map( eval( ($dr: this["dataResourceUid"]) !=null ))
-//        eval(SensitivityZone.isInAustralia($zones))
+//        eval(SensitivityZone.isInAtlasCountry($zones))
 //    then
 //        state.setLoadable(false);
 //        // The warning message for the submitter?
@@ -50,7 +50,7 @@ rule "In Australia"
         $zones : List()
         $st : SensitiveTaxon(name !="Bactrocera tryoni")
         $map: Map()
-        eval(SensitivityZone.isInAustralia($zones) && !SensitivityZone.isInTorresStrait($zones))
+        eval(SensitivityZone.isInAtlasCountry($zones) && !SensitivityZone.isInTorresStrait($zones))
     then
         state.setLoadable(false);
         // The warning message for the submitter?
@@ -95,7 +95,7 @@ rule "Not in Australia"
     when
         $zones : List()
         $st: SensitiveTaxon(name != "Bactrocera tryoni")
-        eval(SensitivityZone.isNotInAustralia($zones))
+        eval(SensitivityZone.isNotInAtlasCountry($zones))
     then
         state.setLoadable(true);
         state.setAnnotation(MessageFactory.getMessageText(MessageFactory.PLANT_PEST_MSG_CAT1_D1), $st.getTaxonName());

--- a/src/main/resources/PBC10-IdentificationToHigherTaxon.drl
+++ b/src/main/resources/PBC10-IdentificationToHigherTaxon.drl
@@ -24,7 +24,7 @@ rule "PBC10-IdentificationToHigherTaxon"
         $data: Map()
         $st : SensitiveTaxon()
         $zones : List()
-        eval((SensitivityZone.isInAustralia($zones) ||SensitivityZone.isExternalTerritory($zones) || SensitivityZone.isInTorresStrait($zones)) && PlantPestUtils.isExactMatch($data,$st))
+        eval((SensitivityZone.isInAtlasCountry($zones) ||SensitivityZone.isExternalTerritory($zones) || SensitivityZone.isInTorresStrait($zones)) && PlantPestUtils.isExactMatch($data,$st))
     then
         // Category 10 is loadable but the data available is restricted from the general public
         state.setLoadable(true);
@@ -40,7 +40,7 @@ rule "Not Extact Match or Outside Australia"
         $data: Map()
         $st : SensitiveTaxon()
         $zones : List()
-        eval(!(SensitivityZone.isInAustralia($zones) ||SensitivityZone.isExternalTerritory($zones) || SensitivityZone.isInTorresStrait($zones)) || !PlantPestUtils.isExactMatch($data,$st))
+        eval(!(SensitivityZone.isInAtlasCountry($zones) ||SensitivityZone.isExternalTerritory($zones) || SensitivityZone.isInTorresStrait($zones)) || !PlantPestUtils.isExactMatch($data,$st))
     then
         state.setLoadable(true);
         logger.debug("PBC10 Rule Not applicable in this situation");

--- a/src/main/resources/PBC3-PlantPestUnderEradication.drl
+++ b/src/main/resources/PBC3-PlantPestUnderEradication.drl
@@ -25,7 +25,7 @@ rule "Temporary catch all rule for species that are under eradication"
         $st : SensitiveTaxon()
         $zones: List()
         $map :Map()
-        eval(SensitivityZone.isInAustralia($zones))
+        eval(SensitivityZone.isInAtlasCountry($zones))
     then
         state.setLoadable(true);
         state.setControlledAccess(true);

--- a/src/main/resources/PBC8-PlantPestTransient.drl
+++ b/src/main/resources/PBC8-PlantPestTransient.drl
@@ -25,7 +25,7 @@ rule "Transient: non actionable"
         $st : SensitiveTaxon()
         $zones : List()
         $date : Date()
-        eval(SensitivityZone.isInAustralia($zones) && PlantPestUtils.isANonActionableTransientEvent($st, SensitivityCategory.PLANT_PEST_NON_TRANSIENT, $date, $zones))
+        eval(SensitivityZone.isInAtlasCountry($zones) && PlantPestUtils.isANonActionableTransientEvent($st, SensitivityCategory.PLANT_PEST_NON_TRANSIENT, $date, $zones))
     then
         //the record can be loaded but it needs restricted attributes.
         state.setLoadable(true);
@@ -50,7 +50,7 @@ rule "Not Transient"
         $st : SensitiveTaxon()
         $zones : List()
         $date : Date()
-        eval(!SensitivityZone.isInAustralia($zones) || !PlantPestUtils.isANonActionableTransientEvent($st, SensitivityCategory.PLANT_PEST_NON_TRANSIENT, $date, $zones))
+        eval(!SensitivityZone.isInAtlasCountry($zones) || !PlantPestUtils.isANonActionableTransientEvent($st, SensitivityCategory.PLANT_PEST_NON_TRANSIENT, $date, $zones))
     then
         logger.debug("PBC8 Rule Not applicable in this situation - checking PBC1");
         state.setDelegateRules("PBC1");

--- a/src/main/resources/PBC9-ExoticBiologicalControlAgent.drl
+++ b/src/main/resources/PBC9-ExoticBiologicalControlAgent.drl
@@ -18,7 +18,7 @@ rule "Is Unreleased Exotic Biological Control Agent"
     when
         $st : SensitiveTaxon()
         $zones : List()
-        eval(SensitivityZone.isInAustralia($zones))
+        eval(SensitivityZone.isInAtlasCountry($zones))
     then
         // Category 9 is loadable but the data available is restricted from the general public
         state.setLoadable(true);

--- a/src/test/java/au/org/ala/sds/model/SensitivityZoneTest.java
+++ b/src/test/java/au/org/ala/sds/model/SensitivityZoneTest.java
@@ -29,7 +29,7 @@ public class SensitivityZoneTest {
 
     @Test
     public void isInAustralia() {
-        assertTrue(SensitivityZone.isInAustralia(SensitivityZoneFactory.getZone(SensitivityZone.NSW)));
-        assertFalse(SensitivityZone.isInAustralia(SensitivityZoneFactory.getZone(SensitivityZone.NOTAUS)));
+        assertTrue(SensitivityZone.isInAtlasCountry(SensitivityZoneFactory.getZone(SensitivityZone.NSW)));
+        assertFalse(SensitivityZone.isInAtlasCountry(SensitivityZoneFactory.getZone(SensitivityZone.NOT_ATLAS_COUNTRY_CODE)));
     }
 }


### PR DESCRIPTION
This PR adds two new configs to allow setup the `AUS` and `NOTAUS` previously hardcoded zone ids as described in #35. It uses the previous ALA values as defaults.